### PR TITLE
Better memory monitoring

### DIFF
--- a/server/modules/system.js
+++ b/server/modules/system.js
@@ -1,16 +1,20 @@
-const {networkStats, networkConnections} = require("systeminformation")
+const {networkStats, networkConnections, mem} = require("systeminformation")
 const os = require("os")
 const {execSync, exec} = require("child_process")
 const {stat, readFile} = require("fs")
 
-const getMem = () => {
-    const total = os.totalmem()
-    const free = os.freemem()
-    return {
-        total,
-        free,
-        used: total - free,
-        process: process.memoryUsage()
+async function getMem() {
+    try {
+        const memInfo = await mem()
+        const {total, available, active } = memInfo
+        return({
+            total,
+            free: available,
+            used: active,
+            process: process.memoryUsage()
+        })
+    } catch (err) {
+        console.log(err)
     }
 }
 
@@ -232,7 +236,7 @@ const getCpuTemperature = () => {
 const sysInfo = async (obj) => {
     switch (obj) {
         case 'cpu': return getCpuInfo()
-        case 'mem': return getMem()
+        case 'mem': return await getMem()
         case 'platform': return getPlatform()
         case 'time': return getServerTime()
         case 'cpu-load': return await getCpuLoad()


### PR DESCRIPTION
This PR improves memory monitoring on Linux-based hosts.

Node's `os.freemem` doesn't represent how much ram is available for processes. It returns what is shown in `cat /proc/meminfo`  `MemFree`, which is calculated from memory used by different applications + buffers + Linux disk in-memory caching.  This means that's it's ok to have `MemFree` close to 0 on Linux host, because Linux can always unload disk caches and buffers from memory without any harm to running processes. To clarify this,  [Linux developers added](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773) new field in `/proc/meminfo`  called `MemAvailable`. This filed represent real free memory capacity for applications on host, without including disk caching. 

So, if monitoring should answer the question `Is it enough free RAM on my host to run an application?` it should use `MemAvailable` parameter. That's why I think it should be better to switch memory monitoring on this parameter, instead of `MemFree`.

Unfortunately, there is no way to get `MemAvailable` from `node.os`, but thankfully `systeminformation` is already in use, and you can get `MemAvailable` there.

Also here is a little bit more information about `free vs available` https://www.linuxatemyram.com/